### PR TITLE
fix: wrong link was got when assets contained multiple files

### DIFF
--- a/run.py
+++ b/run.py
@@ -92,7 +92,10 @@ for plugin in plugins:
         for _i, json_data in enumerate(json_datas):
             if _i == 2:
                 break
-            download_url = json_data['assets'][0]['browser_download_url']
+            for asset in json_data['assets']:
+                if asset['content_type'] == 'application/x-xpinstall':
+                    download_url = asset['browser_download_url']
+                    break
             update_time = datetime.strptime(json_data['assets'][0]['updated_at'], "%Y-%m-%dT%H:%M:%SZ")
             tag_name = json_data['tag_name']
 
@@ -111,7 +114,10 @@ for plugin in plugins:
         resp = requests.get(api_url, headers=headers)
         # resp = requests.get(api_url)
         json_data = resp.json()
-        download_url = json_data['assets'][0]['browser_download_url']
+        for asset in json_data['assets']:
+            if asset['content_type'] == 'application/x-xpinstall':
+                download_url = asset['browser_download_url']
+                break
         update_time = datetime.strptime(json_data['assets'][0]['updated_at'], "%Y-%m-%dT%H:%M:%SZ")
         tag_name = json_data['tag_name']
 


### PR DESCRIPTION
当 release assets 里含有多个附件时，获取到的下载链接可能不是 XPI 文件的链接，
例如 https://github.com/northword/zotero-format-metadata/releases ，release 含有 update.json 和 xpi 两个附件，修改前获取到的是 json 的链接。
这个 PR 添加了 content_type 的校验，确保获得的链接是 xpi 文件的链接。